### PR TITLE
Use 'lodash/assignIn' to avoid bundling all of lodash.

### DIFF
--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -1,4 +1,4 @@
-import _ from 'lodash';
+import assignIn from 'lodash/assignIn';
 
 import {
   DISPATCH_TYPE,
@@ -45,7 +45,7 @@ class Store {
         payload: data
       }, ({error, value}) => {
         if (error) {
-          reject(_.extend((new Error()), error));
+          reject(assignIn((new Error()), error));
         } else {
           resolve(value.payload);
         }


### PR DESCRIPTION
Closes #2.

This change imports `'lodash/assignIn'` instead of `'lodash'` to avoid all of `lodash` being included.
In a project I am working on, this reduced bundle size by approximately 1MB (unminified).