### PR TITLE
include alias example and architecture in README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,10 @@ logs
 *.log
 npm-debug.log*
 
+# text editor artifacts
+*.swp
+*.DS_Store
+
 # Runtime data
 pids
 *.pid


### PR DESCRIPTION
Basic additions to reduce the confusion around the library:

1. Include a link to the full docs/wiki in the header of "Basic Usage".
2. Include a simple diagram to explain what a proxy store is doing.
3. Add a 3rd optional step to create aliases and explain what they are in "Basic Usage" since this is inevitably something anyone who's making a full-fledged extension will want to do.

Really basic for now and not where I'd like the docs to be, but what do you think? Thanks for the patience @tshaddix.