### PR TITLE
Included sender information in action information

### DIFF
--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -44,7 +44,11 @@ export default (store, {
    */
   chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.type === DISPATCH_TYPE) {
-      dispatchResponder(store.dispatch(request.payload), sendResponse);
+      const action = Object.assign({}, request.payload, {
+        _sender: sender,
+      });
+
+      dispatchResponder(store.dispatch(action), sendResponse);
       return true;
     }
   });

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -45,7 +45,7 @@ export default (store, {
   chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
     if (request.type === DISPATCH_TYPE) {
       const action = Object.assign({}, request.payload, {
-        _sender: sender,
+        _sender: sender
       });
 
       dispatchResponder(store.dispatch(action), sendResponse);


### PR DESCRIPTION
It can be helpful to know about who sent the message/action. An example
of why this might be helpful is when using a content script to perform
something tab specific. Without the tab information you won't be able
to get the Tab ID or other useful information about where the action
came from.

The exact use case I have is I'm creating a Chrome extension that has
a page action. The page action should only be available based on the
availability of a script being on the page (it's a work thing). Chrome
allows for this on a per tab basis but you need the tab ID to be able
to do this. My content script can't access this information except by
sending a message. I'm already sending a message when I dispatch
an action. It would be helpful to get this information from the action
on the background side of the extension.