### PR TITLE
Support page messaging

### DIFF
--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -10,7 +10,7 @@ class Store {
    * Creates a new Proxy store
    * @param  {object} options An object of form {portName, state}, where `portName` is a required string and defines the name of the port for state transition changes and `state` is the initial state of this store (default `{}`)
    */
-  constructor(extensionId, {portName, state = {}}) {
+  constructor({portName, state = {}, extensionId = ''}) {
     if (!portName) {
       throw new Error('portName is required in options');
     }

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -72,7 +72,6 @@ class Store {
         type: DISPATCH_TYPE,
         payload: data
       }, ({error, value}) => {
-        //console.log('Error: ', error);
         if (error) {
           reject(assignIn((new Error()), error));
         } else {

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -8,7 +8,7 @@ import {
 class Store {
   /**
    * Creates a new Proxy store
-   * @param  {object} options An object of form {portName, state}, where `portName` is a required string and defines the name of the port for state transition changes and `state` is the initial state of this store (default `{}`)
+   * @param  {object} options An object of form {portName, state, extensionId}, where `portName` is a required string and defines the name of the port for state transition changes, `state` is the initial state of this store (default `{}`) `extensionId` is the extension id as defined by chrome when extension is loaded (default `''`)
    */
   constructor({portName, state = {}, extensionId = ''}) {
     if (!portName) {

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -10,12 +10,12 @@ class Store {
    * Creates a new Proxy store
    * @param  {object} options An object of form {portName, state}, where `portName` is a required string and defines the name of the port for state transition changes and `state` is the initial state of this store (default `{}`)
    */
-  constructor({portName, state = {}}) {
+  constructor(extensionId, {portName, state = {}}) {
     if (!portName) {
       throw new Error('portName is required in options');
     }
-
-    this.port = chrome.runtime.connect({name: portName});
+    this.extensionId = extensionId; //keep the extensionId as an instance variable
+    this.port = chrome.runtime.connect(this.extensionId, {name: portName});
     this.listeners = [];
     this.state = state;
 
@@ -24,6 +24,8 @@ class Store {
         this.replaceState(message.payload);
       }
     });
+
+    this.dispatch = this.dispatch.bind(this); //add this context to dispatch
   }
 
   /**
@@ -64,10 +66,13 @@ class Store {
    */
   dispatch(data) {
     return new Promise((resolve, reject) => {
-      chrome.runtime.sendMessage({
+      chrome.runtime.sendMessage(
+        this.extensionId,
+      {
         type: DISPATCH_TYPE,
         payload: data
       }, ({error, value}) => {
+        //console.log('Error: ', error);
         if (error) {
           reject(assignIn((new Error()), error));
         } else {

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -40,23 +40,23 @@ export default (store, {
   }
 
   /**
-   * Setup action handler to respond to dispatches from UI components
+   * Respond to dispatches from UI components
    */
-  chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+  const dispatchResponse = (request, sender, sendResponse) => {
     if (request.type === DISPATCH_TYPE) {
       const action = Object.assign({}, request.payload, {
         _sender: sender
       });
-
       dispatchResponder(store.dispatch(action), sendResponse);
       return true;
     }
-  });
+  };
 
   /**
-   * Setup extended connection for state updates
-   */
-  chrome.runtime.onConnect.addListener((port) => {
+  * Setup for state updates
+  */
+  const connectState = (port) => {
+    console.log('connected on port: ', port);
     if (port.name !== portName) {
       return;
     }
@@ -80,5 +80,34 @@ export default (store, {
 
     // send initial state
     sendState();
+  };
+
+  /**
+   * Setup action handler
+   */
+  chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
+    return dispatchResponse(request, sender, sendResponse);
   });
+
+  /**
+   * Setup external action handler
+   */
+  chrome.runtime.onMessageExternal.addListener((request, sender, sendResponse) => {
+    return dispatchResponse(request, sender, sendResponse);
+  });
+
+  /**
+   * Setup extended connection
+   */
+  chrome.runtime.onConnect.addListener((port) => {
+    return connectState(port);
+  });
+
+  /**
+   * Setup extended external connection 
+   */
+  chrome.runtime.onConnectExternal.addListener((port) => {
+    return connectState(port);
+  });
+
 };

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -56,7 +56,6 @@ export default (store, {
   * Setup for state updates
   */
   const connectState = (port) => {
-    console.log('connected on port: ', port);
     if (port.name !== portName) {
       return;
     }
@@ -85,29 +84,21 @@ export default (store, {
   /**
    * Setup action handler
    */
-  chrome.runtime.onMessage.addListener((request, sender, sendResponse) => {
-    return dispatchResponse(request, sender, sendResponse);
-  });
+  chrome.runtime.onMessage.addListener(dispatchResponse);
 
   /**
    * Setup external action handler
    */
-  chrome.runtime.onMessageExternal.addListener((request, sender, sendResponse) => {
-    return dispatchResponse(request, sender, sendResponse);
-  });
+  chrome.runtime.onMessageExternal.addListener(dispatchResponse);
 
   /**
    * Setup extended connection
    */
-  chrome.runtime.onConnect.addListener((port) => {
-    return connectState(port);
-  });
+  chrome.runtime.onConnect.addListener(connectState);
 
   /**
    * Setup extended external connection 
    */
-  chrome.runtime.onConnectExternal.addListener((port) => {
-    return connectState(port);
-  });
+  chrome.runtime.onConnectExternal.addListener(connectState);
 
 };

--- a/test/Store.test.js
+++ b/test/Store.test.js
@@ -143,7 +143,21 @@ describe('Store', function() {
   });
 
   describe('#dispatch()', function() {
-    it('should send a message with the correct dispatch type and payload', function() {
+    it('should send a message with the correct dispatch type and payload given an extensionId', function() {
+      var spy = global.chrome.runtime.sendMessage = sinon.spy();
+
+      var store = new Store({portName: 'test', extensionId: 'xxxxxxxxxxxx'});
+
+      store.dispatch({a: 'a'});
+
+      spy.calledOnce.should.eql(true);
+      spy.alwaysCalledWith('xxxxxxxxxxxx', {
+        type: constants.DISPATCH_TYPE,
+        payload: {a: 'a'}
+      }).should.eql(true);
+    });
+
+    it('should send a message with the correct dispatch type and payload not given an extensionId', function() {
       var spy = global.chrome.runtime.sendMessage = sinon.spy();
 
       var store = new Store({portName: 'test'});
@@ -151,14 +165,14 @@ describe('Store', function() {
       store.dispatch({a: 'a'});
 
       spy.calledOnce.should.eql(true);
-      spy.alwaysCalledWith({
+      spy.alwaysCalledWith('', {
         type: constants.DISPATCH_TYPE,
         payload: {a: 'a'}
       }).should.eql(true);
     });
 
     it('should return a promise that resolves with successful action', function() {
-      global.chrome.runtime.sendMessage = function(data, cb) {
+      global.chrome.runtime.sendMessage = function(extensionId, data, cb) {
         cb({value: {payload: 'hello'}});
       };
 
@@ -170,7 +184,7 @@ describe('Store', function() {
     });
 
     it('should return a promise that rejects with an action error', function() {
-      global.chrome.runtime.sendMessage = function(data, cb) {
+      global.chrome.runtime.sendMessage = function(extensionId, data, cb) {
         cb({value: {payload: 'hello'}, error: {extraMsg: 'test'}});
       };
 
@@ -188,7 +202,7 @@ describe('Store', function() {
     });
 
     it('should return a promise that resolves with undefined for an undefined return value', function() {
-      global.chrome.runtime.sendMessage = function(data, cb) {
+      global.chrome.runtime.sendMessage = function(extensionId, data, cb) {
         cb({value: undefined});
       };
 


### PR DESCRIPTION
I've added an optional `extensionId` to the `Store` constructor. I use the extensionId in the `connect` and `sendMessage` functions, and listen for `onMessageExternal` and `onConnectExternal` in the `background.js`. fixes #49 