### PR TITLE
Better error message when there's any error occur in dispatching action.

### DIFF
--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -68,19 +68,13 @@ class Store {
         type: DISPATCH_TYPE,
         payload: data
       }, (resp) => {
-        if (typeof resp === 'undefined') {
-          throw new Error(
-            "Looks like there is an error in the background page. " +
-            "You might want to inspect your background page for more details."
-          );
-        }
-
         const {error, value} = resp;
 
         if (error) {
-          reject(assignIn((new Error()), error));
-          console.error(error);
-          throw new Error(error);
+          let errMsg = "\nLooks like there is an error in the background page. " +
+            "You might want to inspect your background page for more details.\n" +
+            error;
+          reject(assignIn((new Error(errMsg)), error));
         } else {
           resolve(value && value.payload);
         }

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -5,6 +5,9 @@ import {
   STATE_TYPE
 } from '../constants';
 
+const backgroundErrPrefix = '\nLooks like there is an error in the background page. ' +
+  'You might want to inspect your background page for more details.\n';
+
 class Store {
   /**
    * Creates a new Proxy store
@@ -75,10 +78,8 @@ class Store {
         const {error, value} = resp;
 
         if (error) {
-          let errMsg = "\nLooks like there is an error in the background page. " +
-            "You might want to inspect your background page for more details.\n" +
-            error;
-          reject(assignIn((new Error(errMsg)), error));
+          const bgErr = new Error(`${backgroundErrPrefix}${error}`);
+          reject(assignIn(bgErr, error));
         } else {
           resolve(value && value.payload);
         }

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -67,7 +67,17 @@ class Store {
       chrome.runtime.sendMessage({
         type: DISPATCH_TYPE,
         payload: data
-      }, ({error, value}) => {
+      }, (resp) => {
+        if (resp === undefined) {
+          throw(
+            "Looks like there is an error in the background page. " +
+            "You might want to inspect your background page for more details."
+          );
+        }
+
+        let error = resp.error;
+        let value = resp.value;
+
         if (error) {
           reject(assignIn((new Error()), error));
         } else {

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -68,15 +68,14 @@ class Store {
         type: DISPATCH_TYPE,
         payload: data
       }, (resp) => {
-        if (resp === undefined) {
-          throw(
+        if (typeof resp === 'undefined') {
+          throw new Error(
             "Looks like there is an error in the background page. " +
             "You might want to inspect your background page for more details."
           );
         }
 
-        let error = resp.error;
-        let value = resp.value;
+        const {error, value} = resp;
 
         if (error) {
           reject(assignIn((new Error()), error));

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -79,6 +79,8 @@ class Store {
 
         if (error) {
           reject(assignIn((new Error()), error));
+          console.error(error);
+          throw new Error(error);
         } else {
           resolve(value && value.payload);
         }

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -52,9 +52,9 @@ export default (store, {
 
       try {
         dispatchResult = store.dispatch(action);
-      } catch(e) {
-        dispatchResult = { error: e.message };
-        throw e;
+      } catch (e) {
+        dispatchResult = Promise.reject(e.message);
+        console.error(e);
       } finally {
         dispatchResponder(dispatchResult, sendResponse);
         return true;

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -48,8 +48,17 @@ export default (store, {
         _sender: sender
       });
 
-      dispatchResponder(store.dispatch(action), sendResponse);
-      return true;
+      let dispatchResult = null;
+
+      try {
+        dispatchResult = store.dispatch(action);
+      } catch(e) {
+        dispatchResult = { error: e.message };
+        throw e;
+      } finally {
+        dispatchResponder(dispatchResult, sendResponse);
+        return true;
+      }
     }
   });
 

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -55,10 +55,10 @@ export default (store, {
       } catch (e) {
         dispatchResult = Promise.reject(e.message);
         console.error(e);
-      } finally {
-        dispatchResponder(dispatchResult, sendResponse);
-        return true;
       }
+
+      dispatchResponder(dispatchResult, sendResponse);
+      return true;
     }
   };
 


### PR DESCRIPTION
Refer to this SO thread 
http://stackoverflow.com/questions/41379879/typeerror-cannot-read-property-error-of-undefined-on-react-chrome-extension/41775912#41775912

This PR will take care of the situation when there is an error thrown in the reducer, inspecting the popup/content page gives very vague error message. I don't see the need of propagating the error to the popup/content page. But it's helpful to point people to the right place.