### PR TITLE
Conditional check external message support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chrome-redux",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "A set of utilities for building Redux applications in Google Chrome Extensions.",
   "main": "lib/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-chrome-redux",
-  "version": "1.4.0",
+  "version": "1.3.1",
   "description": "A set of utilities for building Redux applications in Google Chrome Extensions.",
   "main": "lib/index.js",
   "scripts": {

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -99,7 +99,9 @@ export default (store, {
   /**
    * Setup external action handler
    */
-  chrome.runtime.onMessageExternal.addListener(dispatchResponse);
+  if (chrome.runtime.onMessageExternal) {
+    chrome.runtime.onMessageExternal.addListener(dispatchResponse);
+  }
 
   /**
    * Setup extended connection
@@ -109,6 +111,7 @@ export default (store, {
   /**
    * Setup extended external connection 
    */
-  chrome.runtime.onConnectExternal.addListener(connectState);
-
+  if (chrome.runtime.onConnectExternal) {
+    chrome.runtime.onConnectExternal.addListener(connectState);
+  }
 };

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -101,6 +101,8 @@ export default (store, {
    */
   if (chrome.runtime.onMessageExternal) {
     chrome.runtime.onMessageExternal.addListener(dispatchResponse);
+  } else {
+    console.warn('runtime.onMessageExternal is not supported');
   }
 
   /**
@@ -113,5 +115,7 @@ export default (store, {
    */
   if (chrome.runtime.onConnectExternal) {
     chrome.runtime.onConnectExternal.addListener(connectState);
+  } else {
+    console.warn('runtime.onConnectExternal is not supported');
   }
 };


### PR DESCRIPTION
Web Extension support is broken because Firefox does not support
`external` namespace messaging.

Added checks in `wrapStore` to make sure the external listeners are
actually defined before adding.

Fixes #54