### PR TITLE
fix error during dispatch not showing up in background page

### DIFF
--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -19,8 +19,9 @@ const promiseResponder = (dispatchResult, send) => {
       });
     })
     .catch((err) => {
+      console.error(err);
       send({
-        error: err,
+        error: err.message,
         value: null
       });
     });

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -19,7 +19,7 @@ const promiseResponder = (dispatchResult, send) => {
       });
     })
     .catch((err) => {
-      console.error(err);
+      console.error('error dispatching result:', err);
       send({
         error: err.message,
         value: null


### PR DESCRIPTION
When there is an error within dispatch, it would not show in the background page. So you would see the error popping on popup/content page, and directing you to inspect the background page, but see nothing in the background page. To replicate this, simply throw an error in alias.

This PR is intending to fix that, and also display the error message occurred in the background when you see the error prompting in popup/content.