### PR TITLE
Linting

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,33 +1,45 @@
 {
-  "rules": {
-    "indent": [
-      2,
-      4
-    ],
-    "quotes": [
-      2,
-      "single"
-    ],
-    "linebreak-style": [
-      2,
-      "unix"
-    ],
-    "semi": [
-      2,
-      "always"
-    ]
-  },
+  "extends": ["eslint:recommended"],
   "env": {
     "es6": true,
-    "node": true,
-    "browser": true
+    "browser": true,
+    "commonjs": true,
+    "jquery": true
   },
-  "extends": "eslint:recommended",
-  "ecmaFeatures": {
-    "jsx": true,
-    "experimentalObjectRestSpread": true
+  "globals": {
+    "chrome": true
   },
-  "plugins": [
-    "react"
-  ]
+  "parser": "babel-eslint",
+  "rules": {
+    "arrow-spacing": "error",
+    "block-spacing": "error",
+    "curly": "error",
+    "default-case": "error",
+    "indent": [2, 2, {"SwitchCase": 1, "VariableDeclarator": {"var": 2, "let": 2, "const": 3}}],
+    "newline-after-var": ["error", "always"],
+    "no-console": 0,
+    "no-debugger": "error",
+    "no-else-return": "error",
+    "no-extra-bind": "error",
+    "no-implicit-coercion": "error",
+    "no-multi-spaces": ["error", { "exceptions": { "VariableDeclarator": true, "AssignmentExpression": true } }],
+    "no-template-curly-in-string": "error",
+    "no-trailing-spaces": "warn",
+    "no-undef-init": "error",
+    "no-unused-vars": "error",
+    "no-var": 1,
+    "object-shorthand": "error",
+    "prefer-arrow-callback": "error",
+    "prefer-const": "error",
+    "prefer-reflect": "error",
+    "require-await": "error",
+    "semi": "error",
+    "space-before-function-paren": ["error", {
+      "anonymous": "always",
+      "named": "never",
+      "asyncArrow": "ignore"
+    }],
+    "spaced-comment": 1,
+    "strict": "error"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -4,9 +4,10 @@
   "description": "A set of utilities for building Redux applications in Google Chrome Extensions.",
   "main": "lib/index.js",
   "scripts": {
+    "lint": "./node_modules/.bin/eslint src/**/*.js && ./node_modules/.bin/eslint test/**/*.js",
     "prepublish": "./node_modules/.bin/babel src --out-dir lib",
     "pretest": "./node_modules/.bin/babel src --out-dir lib",
-    "test": "./node_modules/.bin/mocha --compilers js:babel-core/register"
+    "test": "npm run-script lint && ./node_modules/.bin/mocha --compilers js:babel-core/register"
   },
   "repository": {
     "type": "git",
@@ -25,7 +26,7 @@
     "babel": "^6.3.26",
     "babel-cli": "^6.4.5",
     "babel-core": "^6.22.1",
-    "babel-eslint": "^7.1.0",
+    "babel-eslint": "^7.2.0",
     "babel-plugin-transform-async-to-generator": "^6.22.0",
     "babel-polyfill": "^6.22.0",
     "babel-preset-es2015": "^6.3.13",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,11 @@
     "babel": "^6.3.26",
     "babel-cli": "^6.4.5",
     "babel-core": "^6.22.1",
+    "babel-eslint": "^7.1.0",
     "babel-plugin-transform-async-to-generator": "^6.22.0",
     "babel-polyfill": "^6.22.0",
     "babel-preset-es2015": "^6.3.13",
+    "eslint": "^3.17.1",
     "mocha": "^2.3.4",
     "should": "^8.2.0",
     "sinon": "^1.17.2"

--- a/src/alias/alias.js
+++ b/src/alias/alias.js
@@ -3,12 +3,12 @@
  * another by calling an alias function with the original action
  * @type {object} aliases an object that maps action types (keys) to alias functions (values) (e.g. { SOME_ACTION: newActionAliasFunc })
  */
-export default aliases => store => next => action => {
+export default aliases => () => next => action => {
   const alias = aliases[action.type];
 
   if (alias) {
     return next(alias(action));
-  } else {
-    return next(action);
   }
-}
+
+  return next(action);
+};

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -21,7 +21,7 @@ class Store {
     this.readyResolved = false;
     this.readyPromise = new Promise(resolve => this.readyResolve = resolve);
 
-    this.extensionId = extensionId; //keep the extensionId as an instance variable
+    this.extensionId = extensionId; // keep the extensionId as an instance variable
     this.port = chrome.runtime.connect(this.extensionId, {name: portName});
     this.listeners = [];
     this.state = state;
@@ -37,7 +37,7 @@ class Store {
       }
     });
 
-    this.dispatch = this.dispatch.bind(this); //add this context to dispatch
+    this.dispatch = this.dispatch.bind(this); // add this context to dispatch
   }
 
   /**
@@ -93,19 +93,22 @@ class Store {
     return new Promise((resolve, reject) => {
       chrome.runtime.sendMessage(
         this.extensionId,
-      {
-        type: DISPATCH_TYPE,
-        payload: data
-      }, (resp) => {
-        const {error, value} = resp;
+        {
+          type: DISPATCH_TYPE,
+          payload: data
+        },
+        (resp) => {
+          const {error, value} = resp;
 
-        if (error) {
-          const bgErr = new Error(`${backgroundErrPrefix}${error}`);
-          reject(assignIn(bgErr, error));
-        } else {
-          resolve(value && value.payload);
+          if (error) {
+            const bgErr = new Error(`${backgroundErrPrefix}${error}`);
+
+            reject(assignIn(bgErr, error));
+          } else {
+            resolve(value && value.payload);
+          }
         }
-      });
+      );
     });
   }
 }

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -112,7 +112,7 @@ export default (store, {
   chrome.runtime.onConnect.addListener(connectState);
 
   /**
-   * Setup extended external connection 
+   * Setup extended external connection
    */
   if (chrome.runtime.onConnectExternal) {
     chrome.runtime.onConnectExternal.addListener(connectState);

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -1,5 +1,8 @@
 {
   "env": {
     "mocha": true
+  },
+  "rules": {
+    "prefer-arrow-callback": "error"
   }
 }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -3,6 +3,6 @@
     "mocha": true
   },
   "rules": {
-    "prefer-arrow-callback": "error"
+    "prefer-arrow-callback": 0
   }
 }

--- a/test/Store.test.js
+++ b/test/Store.test.js
@@ -6,33 +6,33 @@ import sinon from 'sinon';
 import { Store } from '../src';
 import { DISPATCH_TYPE, STATE_TYPE } from '../src/constants';
 
-describe('Store', function() {
-  beforeEach(function() {
+describe('Store', function () {
+  beforeEach(function () {
     // Mock chrome.runtime API
     global.chrome = {
       runtime: {
-        connect: function(opts) {
+        connect() {
           return {
             onMessage: {
-              addListener: function(listener) {
+              addListener() {
               }
             }
-          }
+          };
         },
-        sendMessage: function(data, cb) {
+        sendMessage(data, cb) {
           cb();
         }
       }
     };
   });
 
-  describe('#new Store()', function() {
-    it('should setup a listener on the chrome port defined by the portName option and call replaceState on new state messages', function() {
+  describe('#new Store()', function () {
+    it('should setup a listener on the chrome port defined by the portName option and call replaceState on new state messages', function () {
       // mock connect.onMessage listeners array
       const listeners = [];
 
       // override mock chrome API for this test
-      global.chrome.runtime.connect = opts => {
+      global.chrome.runtime.connect = () => {
         return {
           onMessage: {
             addListener: listener => {
@@ -58,7 +58,7 @@ describe('Store', function() {
         payload: {}
       });
 
-      var badMessage = {
+      const badMessage = {
         type: `NOT_${STATE_TYPE}`,
         payload: {}
       };
@@ -71,13 +71,13 @@ describe('Store', function() {
       store.replaceState.alwaysCalledWithExactly(badMessage);
     });
 
-    it('should set the initial state to empty object by default', function() {
+    it('should set the initial state to empty object by default', function () {
       const store = new Store({portName: 'test'});
 
       store.getState().should.eql({});
     });
 
-    it('should set the initial state to opts.state if available', function() {
+    it('should set the initial state to opts.state if available', function () {
       const store = new Store({portName: 'test', state: {a: 'a'}});
 
       store.getState().should.eql({a: 'a'});
@@ -90,10 +90,10 @@ describe('Store', function() {
       const listeners = [];
 
       // override mock chrome API for this test
-      global.chrome.runtime.connect = function(opts) {
+      global.chrome.runtime.connect = () => {
         return {
           onMessage: {
-            addListener: function(listener) {
+            addListener(listener) {
               listeners.push(listener);
             }
           }
@@ -146,8 +146,8 @@ describe('Store', function() {
     });
   });
 
-  describe('#replaceState()', function() {
-    it('should replace the state of the store', function() {
+  describe('#replaceState()', function () {
+    it('should replace the state of the store', function () {
       const store = new Store({portName: 'test'});
 
       store.getState().should.eql({});
@@ -158,8 +158,8 @@ describe('Store', function() {
     });
   });
 
-  describe('#getState()', function() {
-    it('should get the current state of the Store', function() {
+  describe('#getState()', function () {
+    it('should get the current state of the Store', function () {
       const store = new Store({portName: 'test', state: {a: 'a'}});
 
       store.getState().should.eql({a: 'a'});
@@ -170,8 +170,8 @@ describe('Store', function() {
     });
   });
 
-  describe('#subscribe()', function() {
-    it('should register a listener for state changes', function() {
+  describe('#subscribe()', function () {
+    it('should register a listener for state changes', function () {
       const store = new Store({portName: 'test'}),
             newState = {b: 'b'};
 
@@ -187,7 +187,7 @@ describe('Store', function() {
       callCount.should.eql(1);
     });
 
-    it('should return a function which will unsubscribe the listener', function() {
+    it('should return a function which will unsubscribe the listener', function () {
       const store = new Store({portName: 'test'}),
             listener = sinon.spy(),
             unsub = store.subscribe(listener);
@@ -204,8 +204,8 @@ describe('Store', function() {
     });
   });
 
-  describe('#dispatch()', function() {
-    it('should send a message with the correct dispatch type and payload given an extensionId', function() {
+  describe('#dispatch()', function () {
+    it('should send a message with the correct dispatch type and payload given an extensionId', function () {
       const spy = global.chrome.runtime.sendMessage = sinon.spy(),
             store = new Store({portName: 'test', extensionId: 'xxxxxxxxxxxx'});
 
@@ -218,7 +218,7 @@ describe('Store', function() {
       }).should.eql(true);
     });
 
-    it('should send a message with the correct dispatch type and payload not given an extensionId', function() {
+    it('should send a message with the correct dispatch type and payload not given an extensionId', function () {
       const spy = global.chrome.runtime.sendMessage = sinon.spy(),
             store = new Store({portName: 'test'});
 
@@ -231,7 +231,7 @@ describe('Store', function() {
       }).should.eql(true);
     });
 
-    it('should return a promise that resolves with successful action', function() {
+    it('should return a promise that resolves with successful action', function () {
       global.chrome.runtime.sendMessage = (extensionId, data, cb) => {
         cb({value: {payload: 'hello'}});
       };
@@ -242,7 +242,7 @@ describe('Store', function() {
       return p.should.be.fulfilledWith('hello');
     });
 
-    it('should return a promise that rejects with an action error', function() {
+    it('should return a promise that rejects with an action error', function () {
       global.chrome.runtime.sendMessage = (extensionId, data, cb) => {
         cb({value: {payload: 'hello'}, error: {extraMsg: 'test'}});
       };
@@ -253,13 +253,13 @@ describe('Store', function() {
       return p.should.be.rejectedWith(Error, {extraMsg: 'test'});
     });
 
-    it('should throw an error if portName is not present', function() {
+    it('should throw an error if portName is not present', function () {
       should.throws(() => {
         new Store();
       }, Error);
     });
 
-    it('should return a promise that resolves with undefined for an undefined return value', function() {
+    it('should return a promise that resolves with undefined for an undefined return value', function () {
       global.chrome.runtime.sendMessage = (extensionId, data, cb) => {
         cb({value: undefined});
       };

--- a/test/alias.test.js
+++ b/test/alias.test.js
@@ -10,7 +10,7 @@ const getSessionAction = {
   }
 };
 
-describe('#alias()', function() {
+describe('#alias()', function () {
   const getSessionAlias = sinon.stub().returns({
           type: 'GET_SESSION_ALIAS',
           payload: {
@@ -22,7 +22,7 @@ describe('#alias()', function() {
           GET_SESSION: getSessionAlias
         });
 
-  it('should call an alias when matching action type', function() {
+  it('should call an alias when matching action type', function () {
     const next = sinon.spy();
 
     aliases()(next)(getSessionAction);
@@ -35,7 +35,7 @@ describe('#alias()', function() {
     });
   });
 
-  it('should call original action if no matching alias', function() {
+  it('should call original action if no matching alias', function () {
     const next = sinon.spy();
 
     aliases()(next)({


### PR DESCRIPTION
Easiest lint job ever.

No `prefer-arrow-callback` in `test/` because of scope pollution.

I left all unused function params in comments like so -> ` ( /* store */ )` so you can go through and determine if they should stay there for readability
