### PR TITLE
remove ./node_modules/.bin from npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "A set of utilities for building Redux applications in Google Chrome Extensions.",
   "main": "lib/index.js",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint src/**/*.js && ./node_modules/.bin/eslint test/**/*.js",
-    "prepublish": "./node_modules/.bin/babel src --out-dir lib",
-    "pretest": "./node_modules/.bin/babel src --out-dir lib",
-    "test": "npm run-script lint && ./node_modules/.bin/mocha --compilers js:babel-core/register"
+    "lint": "eslint src/**/*.js && eslint test/**/*.js",
+    "prepublish": "babel src --out-dir lib",
+    "pretest": "babel src --out-dir lib",
+    "test": "npm run-script lint && mocha --compilers js:babel-core/register"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Fixes issue #74, which broke linting and tests on Windows.