### PR TITLE
Add support for middlewares in proxyStore

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "prepublish": "./node_modules/.bin/babel src --out-dir lib",
     "pretest": "./node_modules/.bin/babel src --out-dir lib",
     "test-run": "./node_modules/.bin/mocha --compilers js:babel-core/register",
-    "test": "npm run lint && npm run test-run"
+    "test": "npm run lint && npm run test-run",
+    "prepare": "npm run prepublish"
   },
   "repository": {
     "type": "git",

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,4 @@
-import Store from './store/Store';
-import applyMiddleWare from './store/applyMiddleware';
+import Store, { applyMiddleware } from './store/Store';
 import wrapStore from './wrap-store/wrapStore';
 import alias from './alias/alias';
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import Store from './store/Store';
-import applyMiddleWare from './store/Store';
+import applyMiddleWare from './store/applyMiddleware';
 import wrapStore from './wrap-store/wrapStore';
 import alias from './alias/alias';
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import Store from './store/Store';
+import applyMiddleWare from './store/Store';
 import wrapStore from './wrap-store/wrapStore';
 import alias from './alias/alias';
 
-export {Store, wrapStore, alias};
+export {Store, applyMiddleware, wrapStore, alias};

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -1,5 +1,7 @@
 import assignIn from 'lodash/assignIn';
 
+import { default as applyMiddlewareFn } from './applyMiddleware';
+
 import {
   DISPATCH_TYPE,
   STATE_TYPE,
@@ -10,6 +12,8 @@ import {
 
 const backgroundErrPrefix = '\nLooks like there is an error in the background page. ' +
   'You might want to inspect your background page for more details.\n';
+
+export const applyMiddleware = applyMiddlewareFn;
 
 class Store {
   /**

--- a/src/store/applyMiddleware.js
+++ b/src/store/applyMiddleware.js
@@ -1,0 +1,36 @@
+// Function taken from redux source
+// https://github.com/reactjs/redux/blob/master/src/compose.js
+function compose(...funcs) {
+    if (funcs.length === 0) {
+        return arg => arg
+    }
+
+    if (funcs.length === 1) {
+        return funcs[0]
+    }
+
+    return funcs.reduce((a, b) => (...args) => a(b(...args)))
+}
+
+// Based on redux implementation of applyMiddleware to support all standard
+// redux middlewares
+export default function applyMiddleware(store, ...middlewares) {
+    let dispatch = () => {
+        throw new Error(
+            'Dispatching while constructing your middleware is not allowed. '+
+                'Other middleware would not be applied to this dispatch.'
+        )
+    };
+
+    const middlewareAPI = {
+        getState: store.getState,
+        dispatch: (...args) => dispatch(...args)
+    };
+
+    middlewares = (middlewares || []).map(middleware => middleware(middlewareAPI))
+
+    dispatch = compose(...middlewares)(store.dispatch);
+    store.dispatch = dispatch;
+
+    return store;
+}

--- a/src/store/applyMiddleware.js
+++ b/src/store/applyMiddleware.js
@@ -1,36 +1,36 @@
 // Function taken from redux source
 // https://github.com/reactjs/redux/blob/master/src/compose.js
 function compose(...funcs) {
-    if (funcs.length === 0) {
-        return arg => arg
-    }
+  if (funcs.length === 0) {
+    return arg => arg;
+  }
 
-    if (funcs.length === 1) {
-        return funcs[0]
-    }
+  if (funcs.length === 1) {
+    return funcs[0];
+  }
 
-    return funcs.reduce((a, b) => (...args) => a(b(...args)))
+  return funcs.reduce((a, b) => (...args) => a(b(...args)));
 }
 
 // Based on redux implementation of applyMiddleware to support all standard
 // redux middlewares
 export default function applyMiddleware(store, ...middlewares) {
-    let dispatch = () => {
-        throw new Error(
-            'Dispatching while constructing your middleware is not allowed. '+
-                'Other middleware would not be applied to this dispatch.'
-        )
-    };
+  let dispatch = () => {
+    throw new Error(
+      'Dispatching while constructing your middleware is not allowed. '+
+      'Other middleware would not be applied to this dispatch.'
+    );
+  };
 
-    const middlewareAPI = {
-        getState: store.getState,
-        dispatch: (...args) => dispatch(...args)
-    };
+  const middlewareAPI = {
+    getState: store.getState,
+    dispatch: (...args) => dispatch(...args)
+  };
 
-    middlewares = (middlewares || []).map(middleware => middleware(middlewareAPI))
+  middlewares = (middlewares || []).map(middleware => middleware(middlewareAPI));
 
-    dispatch = compose(...middlewares)(store.dispatch);
-    store.dispatch = dispatch;
+  dispatch = compose(...middlewares)(store.dispatch);
+  store.dispatch = dispatch;
 
-    return store;
+  return store;
 }


### PR DESCRIPTION
- Motivation:
  - Add native support for middleware in UI components (i.e. content scripts)

- Changes:
  - Add `applyMiddleware` function, based on Redux's `applyMiddleware`
  - Function wraps a `Store` object, returning a new store with applied middleware

- Notes:
  - We're having an issue running the tests, which we believe is related to the index.d.ts file
  - If possible, please advise how we might amend the file to run the tests