### PR TITLE
Serialization hooks

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
     "plugins": ["transform-async-to-generator"],
-    "presets": ["es2015"]
+    "presets": ["es2015", "stage-1"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-    "plugins": ["@babel/plugin-transform-async-to-generator"],
-    "presets": ["@babel/preset-env", "@babel/preset-stage-1"]
+    "plugins": ["transform-async-to-generator"],
+    "presets": ["es2015"]
 }

--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,4 @@
 {
-    "plugins": ["transform-async-to-generator"],
-    "presets": ["es2015"]
+    "plugins": ["@babel/plugin-transform-async-to-generator"],
+    "presets": ["@babel/preset-env", "@babel/preset-stage-1"]
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,10 @@
     "chrome": true
   },
   "parser": "babel-eslint",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module"
+  },
   "rules": {
     "arrow-spacing": "error",
     "block-spacing": "error",

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,10 +10,6 @@
     "chrome": true
   },
   "parser": "babel-eslint",
-  "parserOptions": {
-    "ecmaVersion": 6,
-    "sourceType": "module"
-  },
   "rules": {
     "arrow-spacing": "error",
     "block-spacing": "error",

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ function dateReplacer (key, value) {
 
 function dateReviver (key, value) {
   // Look for the custom flag and revive the date
-  return value["_RECOVER_DATE"] ? new Date(value["_RECOVER_DATE"]) : value
+  return value && value["_RECOVER_DATE"] ? new Date(value["_RECOVER_DATE"]) : value
 };
 
 const stringified = JSON.stringify(state, dateReplacer)

--- a/README.md
+++ b/README.md
@@ -161,6 +161,84 @@ No changes are required to your actions, react-chrome-redux automatically adds t
 
 `react-chrome-redux` supports `onMessageExternal` which is fired when a message is sent from another extension, app, or website. By default, if `externally_connectable` is not declared in your extension's manifest, all extensions or apps will be able to send messages to your extension, but no websites will be able to. You can follow [this](https://developer.chrome.com/extensions/manifest/externally_connectable) to address your needs appropriately.
 
+## Custom Serialization
+
+You may wish to implement custom serialization and deserialization logic for communication between the background store and your proxy store(s). Chrome's message passing (which is used to implement this library) automatically serializes messages when they are sent and deserializes them when they are received. In the case that you have non-JSON-ifiable information in your Redux state, like a circular reference or a `Date` object, you will lose information between the background store and the proxy store(s). To manage this, both `wrapStore` and `Store` accept `serializer` and `deserializer` options. These should be functions that take a single parameter, the payload of a message, and return a serialized and deserialized form, respectively. The `serializer` function will be called every time a message is sent, and the `deserializer` function will be called every time a message is received. Note that, in addition to state updates, action creators being passed from your content script(s) to your background page will be serialized and deserialized as well.
+
+### Example
+For example, consider the following `state` in your background page:
+
+```js
+{todos: [
+    {
+      id: 1,
+      text: 'Write a Chrome extension',
+      created: new Date(2018, 0, 1)
+    }
+]}
+```
+
+With no custom serialization, the `state` in your proxy store will look like this:
+
+```js
+{todos: [
+    {
+      id: 1,
+      text: 'Write a Chrome extension',
+      created: {}
+    }
+]}
+```
+
+As you can see, Chrome's message passing has caused your date to disappear. You can pass a custom `serializer` and `deserializer` to both `wrapStore` and `Store` to make sure your dates get preserved:
+
+```js
+// background.js
+
+import {wrapStore} from 'react-chrome-redux';
+
+const store; // a normal Redux store
+
+wrapStore(store, {
+  portName: 'MY_APP',
+  serializer: payload => JSON.stringify(payload, dateReplacer),
+  deserializer: payload => JSON.parse(payload, dateReviver)
+});
+```
+
+```js
+// content.js
+
+import {Store} from 'react-chrome-redux';
+
+const store = new Store({
+  portName: 'MY_APP',
+  serializer: payload => JSON.stringify(payload, dateReplacer),
+  deserializer: payload => JSON.parse(payload, dateReviver)
+});
+```
+
+In this example, `dateReplacer` and `dateReviver` are a custom JSON [replacer](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify) and [reviver](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse) function, respectively. They are defined as such:
+
+```js
+function dateReplacer (key, value) {
+  // Put a custom flag on dates instead of relying on JSON's native
+  // stringification, which would force us to use a regex on the other end
+  return this[key] instanceof Date ? {"_RECOVER_DATE": this[key].getTime()} : value
+};
+
+function dateReviver (key, value) {
+  // Look for the custom flag and revive the date
+  return value["_RECOVER_DATE"] ? new Date(value["_RECOVER_DATE"]) : value
+};
+
+const stringified = JSON.stringify(state, dateReplacer)
+//"{"todos":[{"id":1,"text":"Write a Chrome extension","created":{"_RECOVER_DATE":1514793600000}}]}"
+
+JSON.parse(stringified, dateReviver)
+// {todos: [{ id: 1, text: 'Write a Chrome extension', created: new Date(2018, 0, 1) }]}
+```
+
 ## Docs
 
 * [Introduction](https://github.com/tshaddix/react-chrome-redux/wiki/Introduction)

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,8 @@ export class Store<S = any, A extends redux.Action = redux.Action> {
     portName: string,
     state?: any,
     extensionId?: string,
+    serializer: Function,
+    deserializer: Function
   });
 
   /**
@@ -72,6 +74,8 @@ export function wrapStore<S>(
   configuration: {
     portName: string,
     dispatchResponder?(dispatchResult: any, send: (response: any) => void): void,
+    serializer: Function,
+    deserializer: Function
   },
 ): void;
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,8 +9,8 @@ export class Store<S = any, A extends redux.Action = redux.Action> {
     portName: string,
     state?: any,
     extensionId?: string,
-    serializer: Function,
-    deserializer: Function
+    serializer?: Function,
+    deserializer?: Function
   });
 
   /**
@@ -74,8 +74,8 @@ export function wrapStore<S>(
   configuration: {
     portName: string,
     dispatchResponder?(dispatchResult: any, send: (response: any) => void): void,
-    serializer: Function,
-    deserializer: Function
+    serializer?: Function,
+    deserializer?: Function
   },
 ): void;
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "babel-plugin-transform-async-to-generator": "^6.22.0",
     "babel-polyfill": "^6.22.0",
     "babel-preset-es2015": "^6.3.13",
+    "babel-preset-stage-1": "^6.24.1",
     "eslint": "^3.17.1",
     "mocha": "^2.3.4",
     "should": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "npm run lint-src && npm run lint-test",
     "prepublish": "./node_modules/.bin/babel src --out-dir lib",
     "pretest": "./node_modules/.bin/babel src --out-dir lib",
-    "test-run": "./node_modules/.bin/mocha --compilers js:@babel/register",
+    "test-run": "./node_modules/.bin/mocha --compilers js:babel-core/register",
     "test": "npm run lint && npm run test-run"
   },
   "repository": {
@@ -28,14 +28,12 @@
     "redux": "^3.7.2"
   },
   "devDependencies": {
-    "@babel/cli": "^7.0.0-beta.37",
-    "@babel/core": "^7.0.0-beta.37",
-    "@babel/plugin-transform-async-to-generator": "^7.0.0-beta.37",
-    "@babel/polyfill": "^7.0.0-beta.37",
-    "@babel/preset-env": "^7.0.0-beta.37",
-    "@babel/preset-stage-1": "^7.0.0-beta.37",
-    "@babel/register": "^7.0.0-beta.37",
-    "babel-eslint": "^8.2.1",
+    "babel-cli": "^6.4.5",
+    "babel-core": "^6.22.1",
+    "babel-eslint": "^7.2.0",
+    "babel-plugin-transform-async-to-generator": "^6.22.0",
+    "babel-polyfill": "^6.22.0",
+    "babel-preset-es2015": "^6.3.13",
     "eslint": "^3.17.1",
     "mocha": "^2.3.4",
     "should": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "lint": "npm run lint-src && npm run lint-test",
     "prepublish": "./node_modules/.bin/babel src --out-dir lib",
     "pretest": "./node_modules/.bin/babel src --out-dir lib",
-    "test-run": "./node_modules/.bin/mocha --compilers js:babel-core/register",
+    "test-run": "./node_modules/.bin/mocha --compilers js:@babel/register",
     "test": "npm run lint && npm run test-run"
   },
   "repository": {
@@ -28,12 +28,14 @@
     "redux": "^3.7.2"
   },
   "devDependencies": {
-    "babel-cli": "^6.4.5",
-    "babel-core": "^6.22.1",
-    "babel-eslint": "^7.2.0",
-    "babel-plugin-transform-async-to-generator": "^6.22.0",
-    "babel-polyfill": "^6.22.0",
-    "babel-preset-es2015": "^6.3.13",
+    "@babel/cli": "^7.0.0-beta.37",
+    "@babel/core": "^7.0.0-beta.37",
+    "@babel/plugin-transform-async-to-generator": "^7.0.0-beta.37",
+    "@babel/polyfill": "^7.0.0-beta.37",
+    "@babel/preset-env": "^7.0.0-beta.37",
+    "@babel/preset-stage-1": "^7.0.0-beta.37",
+    "@babel/register": "^7.0.0-beta.37",
+    "babel-eslint": "^8.2.1",
     "eslint": "^3.17.1",
     "mocha": "^2.3.4",
     "should": "^8.2.0",

--- a/src/serialization.js
+++ b/src/serialization.js
@@ -13,9 +13,9 @@ const deserializeListener = (listener, deserializer = noop, shouldDeserialize) =
   if (shouldDeserialize) {
     return (message, ...args) => {
       if (shouldDeserialize(message, ...args)) {
-        listener(transformPayload(message, deserializer), ...args);
+        return listener(transformPayload(message, deserializer), ...args);
       } else {
-        listener(message, ...args);
+        return listener(message, ...args);
       }
     };
   }

--- a/src/serialization.js
+++ b/src/serialization.js
@@ -4,6 +4,8 @@ const transformPayload = (message, transformer = noop) => ({
   ...message,
   // If the message has a payload, transform it. Otherwise,
   // just return a copy of the message.
+  // We return a copy rather than the original message so that we're not
+  // mutating the original action object.
   ...(message.payload ? {payload: transformer(message.payload)} : {})
 });
 

--- a/src/serialization.js
+++ b/src/serialization.js
@@ -1,0 +1,59 @@
+export const noop = (payload) => payload;
+
+const deserializeListener = (listener, deserializer = noop) =>
+  (message, ...args) => {
+    if (message.payload) {
+      message.payload = deserializer(message.payload);
+    }
+    return listener(message, ...args);
+  };
+
+const serializeMessage = (message, serializer = noop) => {
+  if (message.payload) {
+    message.payload = serializer(message.payload);
+  }
+  return message;
+};
+
+/**
+ * Given a deserializer, returns a function that that takes a listener
+ * function as its sole argument and returns a wrapped listener that
+ * automatically deserializes message payloads. The message listener
+ * is expected to take the message as its first argument.
+ * @param {Function} deserializer A function that deserialized a message payload
+ * Example Usage:
+ *   const withJsonDeserializer = withDeserializer(payload => JSON.parse(payload))
+ *   const deserializedChromeListener = withJsonDeserializer(chrome.runtime.onMessage.addListener)
+ *   deserializedChromeListener(message => console.log("Payload:", message.payload))
+ *   chrome.runtime.sendMessage("{'prop':4}")
+ *   //Payload: { prop: 4 }
+ */
+export const withDeserializer = (deserializer = noop) =>
+  (addListenerFn) =>
+    (listener) => addListenerFn(deserializeListener(listener, deserializer));
+
+/**
+ * Given a serializer, returns a function that takes a message sending
+ * function as its sole argument and returns a wrapped message sender that
+ * automaticaly serializes message payloads. The message sender
+ * is expected to take the message as its first argument, unless messageArgIndex
+ * is nonzero, in which case it is expected in the position specified by messageArgIndex.
+ * @param {Function} serializer A function that serializes a message payload
+ * Example Usage:
+ *   const withJsonSerializer = withSerializer(payload => JSON.stringify(payload))
+ *   const serializedChromeSender = withJsonSerializer(chrome.runtime.sendMessage)
+ *   chrome.runtime.addListener(message => console.log("Payload:", message.payload))
+ *   serializedChromeSender({ prop: 4 })
+ *   //Payload: "{'prop':4}"
+ */
+export const withSerializer = (serializer = noop) =>
+  (sendMessageFn, messageArgIndex = 0) => {
+    return (...args) => {
+      if (args.length <= messageArgIndex) {
+        throw new Error(`Message in request could not be serialized. ` +
+                        `Expected message in position ${messageArgIndex} but only received ${args.length} args.`);
+      }
+      args[messageArgIndex] = serializeMessage(args[messageArgIndex], serializer);
+      return sendMessageFn(...args);
+    };
+  };

--- a/src/serialization.js
+++ b/src/serialization.js
@@ -1,36 +1,68 @@
 export const noop = (payload) => payload;
 
-const deserializeListener = (listener, deserializer = noop) =>
-  (message, ...args) => {
-    if (message.payload) {
-      message.payload = deserializer(message.payload);
-    }
-    return listener(message, ...args);
-  };
+const transformPayload = (message, transformer = noop) => ({
+  ...message,
+  // If the message has a payload, transform it. Otherwise,
+  // just return a copy of the message.
+  ...(message.payload ? {payload: transformer(message.payload)} : {})
+});
 
-const serializeMessage = (message, serializer = noop) => {
-  if (message.payload) {
-    message.payload = serializer(message.payload);
+const deserializeListener = (listener, deserializer = noop, shouldDeserialize) => {
+  // If a shouldDeserialize function is passed, return a function that uses it
+  // to check if any given message payload should be deserialized
+  if (shouldDeserialize) {
+    return (message, ...args) => {
+      if (shouldDeserialize(message, ...args)) {
+        listener(transformPayload(message, deserializer), ...args);
+      } else {
+        listener(message, ...args);
+      }
+    };
   }
-  return message;
+  // Otherwise, return a function that tries to deserialize on every message
+  return (message, ...args) => listener(transformPayload(message, deserializer), ...args);
 };
 
 /**
- * Given a deserializer, returns a function that that takes a listener
- * function as its sole argument and returns a wrapped listener that
- * automatically deserializes message payloads. The message listener
- * is expected to take the message as its first argument.
- * @param {Function} deserializer A function that deserialized a message payload
+ * A function returned from withDeserializer that, when called, wraps addListenerFn with the
+ * deserializer passed to withDeserializer.
+ * @name AddListenerDeserializer
+ * @function
+ * @param {Function} addListenerFn The add listener function to wrap.
+ * @returns {DeserializedAddListener}
+ */
+
+/**
+ * A wrapped add listener function that registers the given listener.
+ * @name DeserializedAddListener
+ * @function
+ * @param {Function} listener The listener function to register. It should expect the (optionally)
+ * deserialized message as its first argument.
+ * @param {Function} [shouldDeserialize] A function that takes the arguments passed to the listener
+ * and returns whether the message payload should be deserialized. Not all messages (notably, messages
+ * this listener doesn't care about) should be attempted to be deserialized.
+ */
+
+/**
+ * Given a deserializer, returns an AddListenerDeserializer function that that takes an add listener
+ * function and returns a DeserializedAddListener that automatically deserializes message payloads.
+ * Each message listener is expected to take the message as its first argument.
+ * @param {Function} deserializer A function that deserializes a message payload.
+ * @returns {AddListenerDeserializer}
  * Example Usage:
- *   const withJsonDeserializer = withDeserializer(payload => JSON.parse(payload))
- *   const deserializedChromeListener = withJsonDeserializer(chrome.runtime.onMessage.addListener)
- *   deserializedChromeListener(message => console.log("Payload:", message.payload))
- *   chrome.runtime.sendMessage("{'prop':4}")
- *   //Payload: { prop: 4 }
+ *   const withJsonDeserializer = withDeserializer(payload => JSON.parse(payload));
+ *   const deserializedChromeListener = withJsonDeserializer(chrome.runtime.onMessage.addListener);
+ *   const shouldDeserialize = (message) => message.type === 'DESERIALIZE_ME';
+ *   deserializedChromeListener(message => console.log("Payload:", message.payload), shouldDeserialize);
+ *   chrome.runtime.sendMessage("{'type:'DESERIALIZE_ME','payload':{'prop':4}}");
+ *   //Payload: { prop: 4 };
+ *   chrome.runtime.sendMessage("{'payload':{'prop':4}}");
+ *   //Payload: "{'prop':4}";
  */
 export const withDeserializer = (deserializer = noop) =>
   (addListenerFn) =>
-    (listener) => addListenerFn(deserializeListener(listener, deserializer));
+    (listener, shouldDeserialize) =>
+      addListenerFn(deserializeListener(listener, deserializer, shouldDeserialize));
 
 /**
  * Given a serializer, returns a function that takes a message sending
@@ -43,7 +75,7 @@ export const withDeserializer = (deserializer = noop) =>
  *   const withJsonSerializer = withSerializer(payload => JSON.stringify(payload))
  *   const serializedChromeSender = withJsonSerializer(chrome.runtime.sendMessage)
  *   chrome.runtime.addListener(message => console.log("Payload:", message.payload))
- *   serializedChromeSender({ prop: 4 })
+ *   serializedChromeSender({ payload: { prop: 4 }})
  *   //Payload: "{'prop':4}"
  */
 export const withSerializer = (serializer = noop) =>
@@ -53,7 +85,7 @@ export const withSerializer = (serializer = noop) =>
         throw new Error(`Message in request could not be serialized. ` +
                         `Expected message in position ${messageArgIndex} but only received ${args.length} args.`);
       }
-      args[messageArgIndex] = serializeMessage(args[messageArgIndex], serializer);
+      args[messageArgIndex] = transformPayload(args[messageArgIndex], serializer);
       return sendMessageFn(...args);
     };
   };

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -39,6 +39,7 @@ class Store {
     this.listeners = [];
     this.state = state;
 
+    //Don't use shouldDeserialize here, since no one else should be using this port
     this.serializedPortListener(message => {
       switch (message.type) {
         case STATE_TYPE:

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -39,7 +39,7 @@ class Store {
     this.listeners = [];
     this.state = state;
 
-    //Don't use shouldDeserialize here, since no one else should be using this port
+    // Don't use shouldDeserialize here, since no one else should be using this port
     this.serializedPortListener(message => {
       switch (message.type) {
         case STATE_TYPE:

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -7,6 +7,7 @@ import {
   DIFF_STATUS_UPDATED,
   DIFF_STATUS_REMOVED,
 } from '../constants';
+import { withSerializer, withDeserializer, noop } from "../serialization";
 
 const backgroundErrPrefix = '\nLooks like there is an error in the background page. ' +
   'You might want to inspect your background page for more details.\n';
@@ -14,11 +15,17 @@ const backgroundErrPrefix = '\nLooks like there is an error in the background pa
 class Store {
   /**
    * Creates a new Proxy store
-   * @param  {object} options An object of form {portName, state, extensionId}, where `portName` is a required string and defines the name of the port for state transition changes, `state` is the initial state of this store (default `{}`) `extensionId` is the extension id as defined by chrome when extension is loaded (default `''`)
+   * @param  {object} options An object of form {portName, state, extensionId, serializer, deserializer}, where `portName` is a required string and defines the name of the port for state transition changes, `state` is the initial state of this store (default `{}`) `extensionId` is the extension id as defined by chrome when extension is loaded (default `''`), `serializer` is a function to serialize outgoing message payloads (default is passthrough), and `deserializer` is a function to deserialize incoming message payloads (default is passthrough)
    */
-  constructor({portName, state = {}, extensionId = ''}) {
+  constructor({portName, state = {}, extensionId = '', serializer = noop, deserializer = noop}) {
     if (!portName) {
       throw new Error('portName is required in options');
+    }
+    if (typeof serializer !== 'function') {
+      throw new Error('serializer must be a function');
+    }
+    if (typeof deserializer !== 'function') {
+      throw new Error('deserializer must be a function');
     }
 
     this.portName = portName;
@@ -27,10 +34,12 @@ class Store {
 
     this.extensionId = extensionId; // keep the extensionId as an instance variable
     this.port = chrome.runtime.connect(this.extensionId, {name: portName});
+    this.serializedPortListener = withDeserializer(deserializer)(this.port.onMessage.addListener);
+    this.serializedMessageSender = withSerializer(serializer)(chrome.runtime.sendMessage, 1);
     this.listeners = [];
     this.state = state;
 
-    this.port.onMessage.addListener(message => {
+    this.serializedPortListener(message => {
       switch (message.type) {
         case STATE_TYPE:
           this.replaceState(message.payload);
@@ -138,7 +147,7 @@ class Store {
    */
   dispatch(data) {
     return new Promise((resolve, reject) => {
-      chrome.runtime.sendMessage(
+      this.serializedMessageSender(
         this.extensionId,
         {
           type: DISPATCH_TYPE,

--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -34,8 +34,8 @@ class Store {
 
     this.extensionId = extensionId; // keep the extensionId as an instance variable
     this.port = chrome.runtime.connect(this.extensionId, {name: portName});
-    this.serializedPortListener = withDeserializer(deserializer)(this.port.onMessage.addListener);
-    this.serializedMessageSender = withSerializer(serializer)(chrome.runtime.sendMessage, 1);
+    this.serializedPortListener = withDeserializer(deserializer)((...args) => this.port.onMessage.addListener(...args));
+    this.serializedMessageSender = withSerializer(serializer)((...args) => chrome.runtime.sendMessage(...args), 1);
     this.listeners = [];
     this.state = state;
 

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -120,17 +120,18 @@ export default (store, {
   };
 
   const withPayloadDeserializer = withDeserializer(deserializer);
+  const shouldDeserialize = (request) => request.type === DISPATCH_TYPE && request.portName === portName;
 
   /**
    * Setup action handler
    */
-  withPayloadDeserializer(chrome.runtime.onMessage.addListener)(dispatchResponse);
+  withPayloadDeserializer(chrome.runtime.onMessage.addListener)(dispatchResponse, shouldDeserialize);
 
   /**
    * Setup external action handler
    */
   if (chrome.runtime.onMessageExternal) {
-    withPayloadDeserializer(chrome.runtime.onMessageExternal.addListener)(dispatchResponse);
+    withPayloadDeserializer(chrome.runtime.onMessageExternal.addListener)(dispatchResponse, shouldDeserialize);
   } else {
     console.warn('runtime.onMessageExternal is not supported');
   }

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -88,7 +88,7 @@ export default (store, {
       return;
     }
 
-    const serializedMessagePoster = withSerializer(serializer)(port.postMessage);
+    const serializedMessagePoster = withSerializer(serializer)((...args) => port.postMessage(...args));
 
     let prevState = store.getState();
 
@@ -125,13 +125,13 @@ export default (store, {
   /**
    * Setup action handler
    */
-  withPayloadDeserializer(chrome.runtime.onMessage.addListener)(dispatchResponse, shouldDeserialize);
+  withPayloadDeserializer((...args) => chrome.runtime.onMessage.addListener(...args))(dispatchResponse, shouldDeserialize);
 
   /**
    * Setup external action handler
    */
   if (chrome.runtime.onMessageExternal) {
-    withPayloadDeserializer(chrome.runtime.onMessageExternal.addListener)(dispatchResponse, shouldDeserialize);
+    withPayloadDeserializer((...args) => chrome.runtime.onMessageExternal.addListener(...args))(dispatchResponse, shouldDeserialize);
   } else {
     console.warn('runtime.onMessageExternal is not supported');
   }

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -3,6 +3,7 @@ import {
   STATE_TYPE,
   PATCH_STATE_TYPE,
 } from '../constants';
+import { withSerializer, withDeserializer, noop } from "../serialization";
 
 import shallowDiff from './shallowDiff';
 
@@ -30,12 +31,25 @@ const promiseResponder = (dispatchResult, send) => {
     });
 };
 
+/**
+ * Wraps a Redux store so that proxy stores can connect to it.
+ * @param {Object} store A Redux store
+ * @param {Object} options An object of form {portName, dispatchResponder, serializer, deserializer}, where `portName` is a required string and defines the name of the port for state transition changes, `dispatchResponder` is a function that takes the result of a store dispatch and optionally implements custom logic for responding to the original dispatch message,`serializer` is a function to serialize outgoing message payloads (default is passthrough), and `deserializer` is a function to deserialize incoming message payloads (default is passthrough)
+ */
 export default (store, {
   portName,
-  dispatchResponder
+  dispatchResponder,
+  serializer = noop,
+  deserializer = noop
 }) => {
   if (!portName) {
     throw new Error('portName is required in options');
+  }
+  if (typeof serializer !== 'function') {
+    throw new Error('serializer must be a function');
+  }
+  if (typeof deserializer !== 'function') {
+    throw new Error('deserializer must be a function');
   }
 
   // set dispatch responder as promise responder
@@ -74,6 +88,8 @@ export default (store, {
       return;
     }
 
+    const serializedMessagePoster = withSerializer(serializer)(port.postMessage);
+
     let prevState = store.getState();
 
     const patchState = () => {
@@ -83,7 +99,7 @@ export default (store, {
       if (diff.length) {
         prevState = state;
 
-        port.postMessage({
+        serializedMessagePoster({
           type: PATCH_STATE_TYPE,
           payload: diff,
         });
@@ -97,22 +113,24 @@ export default (store, {
     port.onDisconnect.addListener(unsubscribe);
 
     // Send store's initial state through port
-    port.postMessage({
+    serializedMessagePoster({
       type: STATE_TYPE,
       payload: prevState,
     });
   };
 
+  const withPayloadDeserializer = withDeserializer(deserializer);
+
   /**
    * Setup action handler
    */
-  chrome.runtime.onMessage.addListener(dispatchResponse);
+  withPayloadDeserializer(chrome.runtime.onMessage.addListener)(dispatchResponse);
 
   /**
    * Setup external action handler
    */
   if (chrome.runtime.onMessageExternal) {
-    chrome.runtime.onMessageExternal.addListener(dispatchResponse);
+    withPayloadDeserializer(chrome.runtime.onMessageExternal.addListener)(dispatchResponse);
   } else {
     console.warn('runtime.onMessageExternal is not supported');
   }

--- a/test/Store.test.js
+++ b/test/Store.test.js
@@ -277,12 +277,6 @@ describe('Store', function () {
       return p.should.be.rejectedWith(Error, {extraMsg: 'test'});
     });
 
-    it('should throw an error if portName is not present', function () {
-      should.throws(() => {
-        new Store();
-      }, Error);
-    });
-
     it('should return a promise that resolves with undefined for an undefined return value', function () {
       global.chrome.runtime.sendMessage = (extensionId, data, cb) => {
         cb({value: undefined});
@@ -292,6 +286,26 @@ describe('Store', function () {
             p = store.dispatch({a: 'a'});
 
       return p.should.be.fulfilledWith(undefined);
+    });
+  });
+
+  describe("when validating options", function () {
+    it('should throw an error if portName is not present', function () {
+      should.throws(() => {
+        new Store();
+      }, Error);
+    });
+
+    it('should throw an error if serializer is not a function', function () {
+      should.throws(() => {
+        new Store({portName, serializer: "abc"});
+      }, Error);
+    });
+
+    it('should throw an error if deserializer is not a function', function () {
+      should.throws(() => {
+        new Store({portName, deserializer: "abc"});
+      }, Error);
     });
   });
 });

--- a/test/Store.test.js
+++ b/test/Store.test.js
@@ -1,4 +1,4 @@
-import '@babel/polyfill';
+import 'babel-polyfill';
 
 import should from 'should';
 import sinon from 'sinon';

--- a/test/Store.test.js
+++ b/test/Store.test.js
@@ -53,7 +53,7 @@ describe('Store', function () {
     });
 
     it('should setup a listener on the chrome port defined by the portName option', function () {
-      const store = new Store({portName});
+      new Store({portName});
 
       // verify one listener was added on port connect
       listeners.length.should.equal(1);
@@ -69,7 +69,7 @@ describe('Store', function () {
 
       const payload = {
         a: 1
-      }
+      };
 
       // send one state type message
       l({
@@ -101,7 +101,7 @@ describe('Store', function () {
 
       const payload = {
         a: 1
-      }
+      };
 
       // send one state type message
       l({

--- a/test/Store.test.js
+++ b/test/Store.test.js
@@ -1,4 +1,4 @@
-import 'babel-polyfill';
+import '@babel/polyfill';
 
 import should from 'should';
 import sinon from 'sinon';

--- a/test/Store.test.js
+++ b/test/Store.test.js
@@ -59,23 +59,25 @@ describe('Store', function () {
 
       const [ l ] = listeners;
 
+      const payload = {
+        a: 1
+      }
+
       // send one state type message
       l({
         type: STATE_TYPE,
-        payload: {}
+        payload
       });
 
-      const badMessage = {
-        type: `NOT_${STATE_TYPE}`,
-        payload: {}
-      };
-
       // send one non-state type message
-      l(badMessage);
+      l({
+        type: `NOT_${STATE_TYPE}`,
+        payload
+      });
 
       // make sure replace state was only called once
       store.replaceState.calledOnce.should.equal(true);
-      store.replaceState.alwaysCalledWithExactly(badMessage);
+      store.replaceState.firstCall.args[0].should.eql(payload);
     });
 
     it('should set the initial state to empty object by default', function () {

--- a/test/Store.test.js
+++ b/test/Store.test.js
@@ -306,7 +306,7 @@ describe('Store', function () {
       store.dispatch({a: 'a'});
 
       spy.calledOnce.should.eql(true);
-      spy.alwaysCalledWith('', {
+      spy.alwaysCalledWith(null, {
         type: DISPATCH_TYPE,
         portName,
         payload: JSON.stringify({a: 'a'})

--- a/test/serialization.test.js
+++ b/test/serialization.test.js
@@ -1,7 +1,6 @@
-import 'babel-polyfill';
-
 import should from 'should';
 import sinon from 'sinon';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { withSerializer, withDeserializer } from '../src/serialization';
 
@@ -9,7 +8,8 @@ describe("serialization functions", function () {
   describe("#withSerializer", function () {
     const jsonSerialize = (payload) => JSON.stringify(payload);
 
-    let payload, message;
+    let payload, message, serializedMessage, sender;
+
     beforeEach(function () {
       payload = {
         message: "Hello World",
@@ -20,36 +20,73 @@ describe("serialization functions", function () {
         type: 'TEST',
         payload
       };
+
+      serializedMessage = {
+        type: 'TEST',
+        payload: jsonSerialize(payload)
+      };
+
+      sender = sinon.spy();
     });
 
     it("should serialize the message payload before sending", function () {
-      const sender = sinon.spy();
       const serializedSender = sinon.spy(withSerializer(jsonSerialize)(sender));
 
       serializedSender(message);
 
+      // Assert that sender and serialized sender were called exactly once
       sender.calledOnce.should.eql(true);
       serializedSender.calledOnce.should.eql(true);
-      sender.firstCall.args[0].payload.should.eql(jsonSerialize(payload));
+      // Assert that the sender was called with the serialized payload
+      sender.firstCall.args[0].should.eql(serializedMessage);
     });
 
     it("should enforce the number of arguments", function () {
-      const sender = sinon.spy();
       const serializedSender = withSerializer(jsonSerialize)(sender, 1);
 
+      // Assert that the serialized sender threw due to insufficient arguments
       should.throws(() => serializedSender(message));
+      // Assert that the actual sender was never called
       sender.called.should.eql(false);
     });
 
     it("should extract the correct argument index", function () {
-      const sender = sinon.spy();
       const serializedSender = sinon.spy(withSerializer(jsonSerialize)(sender, 1));
 
       serializedSender(null, message);
 
+      // Assert that sender and serialized sender were called exactly once
       sender.calledOnce.should.eql(true);
       serializedSender.calledOnce.should.eql(true);
-      sender.firstCall.args[1].payload.should.eql(jsonSerialize(payload));
+      // Assert that the message was extracted from the correct argument index
+      sender.firstCall.args[1].should.eql(serializedMessage);
+    });
+
+    it("should have the same result when the same message is sent twice", function () {
+      const serializedSender = sinon.spy(withSerializer(jsonSerialize)(sender));
+
+      serializedSender(message);
+      const firstResult = cloneDeep(sender.firstCall.args[0]);
+
+      serializedSender(message);
+      const secondResult = cloneDeep(sender.secondCall.args[0]);
+
+      // Assert that sender and serialized sender were called exactly twice
+      sender.calledTwice.should.eql(true);
+      serializedSender.calledTwice.should.eql(true);
+      // Assert that the sender was called with the same message both times
+      firstResult.should.eql(secondResult);
+    });
+
+    it("should not modify the original message", function () {
+      const serializedSender = sinon.spy(withSerializer(jsonSerialize)(sender));
+
+      serializedSender(message);
+
+      // Assert deep equality between message payload and the payload object
+      message.payload.should.eql(payload);
+      // Assert that the original message and the sent message were different objects
+      sender.firstCall.args[0].should.not.be.exactly(message);
     });
 
   });
@@ -57,34 +94,103 @@ describe("serialization functions", function () {
   describe("#withDeserializer", function () {
     const jsonDeserialize = (payload) => JSON.parse(payload);
 
-    let payload, message;
+    // Mock a simple listener scenario
+    let listeners;
+    const addListener = listener => {
+      listeners.push(listener);
+    };
+    const onMessage = (message) => {
+      listeners.forEach(listener => {
+        listener(message);
+      });
+    };
+
+    let payload, message, deserializedMessage, listener, serializedAddListener;
+
     beforeEach(function () {
-      payload = {
+      payload = JSON.stringify({
         message: "Hello World",
         numbers: [1, 2, 3]
-      };
+      });
 
       message = {
         type: 'TEST',
-        payload: JSON.stringify(payload)
+        payload
       };
+
+      deserializedMessage = {
+        type: 'TEST',
+        payload: jsonDeserialize(payload)
+      };
+
+      listeners = [];
+      listener = sinon.spy();
+      serializedAddListener = sinon.spy(withDeserializer(jsonDeserialize)(addListener));
     });
 
     it("should deserialize the message payload before the callback", function () {
-      const jsonDeserialize = sinon.spy((payload) => JSON.parse(payload));
-      //Mock a simple listener scenario
-      let listeners = [];
-      const addListener = listener => { listeners.push(listener) };
-      const triggerListeners = (message) => { listeners.forEach(listener => { listener(message) }) };
+      serializedAddListener(listener);
+      onMessage(message);
 
-      const listener = sinon.spy();
-      const serializedListener = sinon.spy(withDeserializer(jsonDeserialize)(addListener));
-      serializedListener(listener);
-
-      triggerListeners(message);
+      // Assert that the listener was called once
       listener.calledOnce.should.eql(true);
-      serializedListener.calledOnce.should.eql(true);
-      listener.firstCall.args[0].payload.should.eql(payload);
+      // Assert that it was called with the deserialized payload
+      listener.firstCall.args[0].should.eql(deserializedMessage);
     });
+
+    it("should only add the listener once", function () {
+      serializedAddListener(listener);
+      onMessage(message);
+      onMessage(message);
+
+      // Assert that the listener was called exactly twice
+      listener.calledTwice.should.eql(true);
+      // Assert that addListener is called once
+      serializedAddListener.calledOnce.should.eql(true);
+    });
+
+    it("should have the same result when the same message is received twice", function () {
+      serializedAddListener(listener);
+
+      onMessage(message);
+      const firstResult = cloneDeep(listener.firstCall.args[0]);
+
+      onMessage(message);
+      const secondResult = cloneDeep(listener.secondCall.args[0]);
+
+      // Assert that the listener was called with the same message both times
+      firstResult.should.eql(secondResult);
+    });
+
+    it("should not modify the original incoming message", function () {
+      serializedAddListener(listener);
+      onMessage(message);
+
+      // Assert deep equality between message payload and the payload object
+      message.payload.should.eql(payload);
+      // Assert that the original message and the received message are different objects
+      listener.firstCall.args[0].should.not.be.exactly(message);
+    });
+
+    it("should not deserialize messages it isn't supposed to", function () {
+      const shouldDeserialize = (message) => message.type === 'DESERIALIZE_ME';
+
+      serializedAddListener(listener, shouldDeserialize);
+      onMessage(message);
+
+      // Assert that the message has not been deserialized
+      listener.firstCall.args[0].should.eql(message);
+    });
+
+    it("should deserialize messages it is supposed to", function () {
+      const shouldDeserialize = (message) => message.type === 'TEST';
+
+      serializedAddListener(listener, shouldDeserialize);
+      onMessage(message);
+
+      // Assert that the message has been deserialized
+      listener.firstCall.args[0].should.eql(deserializedMessage);
+    });
+
   });
 });

--- a/test/serialization.test.js
+++ b/test/serialization.test.js
@@ -1,0 +1,90 @@
+import 'babel-polyfill';
+
+import should from 'should';
+import sinon from 'sinon';
+
+import { withSerializer, withDeserializer } from '../src/serialization';
+
+describe("serialization functions", function () {
+  describe("#withSerializer", function () {
+    const jsonSerialize = (payload) => JSON.stringify(payload);
+
+    let payload, message;
+    beforeEach(function () {
+      payload = {
+        message: "Hello World",
+        numbers: [1, 2, 3]
+      };
+
+      message = {
+        type: 'TEST',
+        payload
+      };
+    });
+
+    it("should serialize the message payload before sending", function () {
+      const sender = sinon.spy();
+      const serializedSender = sinon.spy(withSerializer(jsonSerialize)(sender));
+
+      serializedSender(message);
+
+      sender.calledOnce.should.eql(true);
+      serializedSender.calledOnce.should.eql(true);
+      sender.firstCall.args[0].payload.should.eql(jsonSerialize(payload));
+    });
+
+    it("should enforce the number of arguments", function () {
+      const sender = sinon.spy();
+      const serializedSender = withSerializer(jsonSerialize)(sender, 1);
+
+      should.throws(() => serializedSender(message));
+      sender.called.should.eql(false);
+    });
+
+    it("should extract the correct argument index", function () {
+      const sender = sinon.spy();
+      const serializedSender = sinon.spy(withSerializer(jsonSerialize)(sender, 1));
+
+      serializedSender(null, message);
+
+      sender.calledOnce.should.eql(true);
+      serializedSender.calledOnce.should.eql(true);
+      sender.firstCall.args[1].payload.should.eql(jsonSerialize(payload));
+    });
+
+  });
+
+  describe("#withDeserializer", function () {
+    const jsonDeserialize = (payload) => JSON.parse(payload);
+
+    let payload, message;
+    beforeEach(function () {
+      payload = {
+        message: "Hello World",
+        numbers: [1, 2, 3]
+      };
+
+      message = {
+        type: 'TEST',
+        payload: JSON.stringify(payload)
+      };
+    });
+
+    it("should deserialize the message payload before the callback", function () {
+      const jsonDeserialize = sinon.spy((payload) => JSON.parse(payload));
+      //Mock a simple listener scenario
+      let listeners = [];
+      const addListener = listener => { listeners.push(listener) };
+      const triggerListeners = (message) => { listeners.forEach(listener => { listener(message) }) };
+
+      const listener = sinon.spy();
+      const serializedListener = sinon.spy(withDeserializer(jsonDeserialize)(addListener));
+      serializedListener(listener);
+
+      triggerListeners(message);
+      listener.calledOnce.should.eql(true);
+      serializedListener.calledOnce.should.eql(true);
+      listener.firstCall.args[0].payload.should.eql(payload);
+    });
+  });
+});

--- a/test/wrapStore.test.js
+++ b/test/wrapStore.test.js
@@ -1,4 +1,4 @@
-import '@babel/polyfill';
+import 'babel-polyfill';
 
 import sinon from 'sinon';
 import should from 'should';

--- a/test/wrapStore.test.js
+++ b/test/wrapStore.test.js
@@ -58,10 +58,10 @@ describe('wrapStore', function () {
     return listeners;
   }
 
-  describe("on receiving messages", function() {
+  describe("on receiving messages", function () {
     let listeners, store, payload, message, sender, callback;
 
-    beforeEach(function() {
+    beforeEach(function () {
       listeners = setupListeners();
       store = {
         dispatch: sinon.spy(),
@@ -92,7 +92,7 @@ describe('wrapStore', function () {
         )
         .should.eql(true);
     });
-  
+
     it('should not dispatch actions received on onMessage for other ports', function () {
       wrapStore(store, {portName});
       message.portName = portName + '2';
@@ -100,9 +100,10 @@ describe('wrapStore', function () {
 
       store.dispatch.notCalled.should.eql(true);
     });
-  
+
     it('should deserialize incoming messages correctly', function () {
       const deserializer = sinon.spy(JSON.parse);
+
       wrapStore(store, {portName, deserializer});
       message.payload = JSON.stringify(payload);
       listeners.onMessage.forEach(l => l(message, sender, callback));
@@ -119,6 +120,7 @@ describe('wrapStore', function () {
 
     it('should not deserialize incoming messages for other ports', function () {
       const deserializer = sinon.spy(JSON.parse);
+
       wrapStore(store, {portName, deserializer});
       message.portName = portName + '2';
       message.payload = JSON.stringify(payload);
@@ -130,24 +132,25 @@ describe('wrapStore', function () {
 
   it('should serialize initial state and subsequent patches correctly', function () {
     const listeners = setupListeners();
-    
+
     // Mock store subscription
     const subscribers = [];
     const store = {
       subscribe: subscriber => {
         subscribers.push(subscriber);
-        return () => ({})
+        return () => ({});
       },
       getState: () => ({})
     };
-    
+
     // Stub state access (the first access will be on
     // initialization, and the second will be on update)
     const firstState = { a: 1, b: 2 };
     const secondState = { a: 1, b: 3, c: 5 };
+
     sinon.stub(store, 'getState')
         .onFirstCall().returns(firstState)
-        .onSecondCall().returns(secondState)
+        .onSecondCall().returns(secondState);
 
     // Mock the port object for onConnect and spy on postMessage
     const port = {
@@ -170,7 +173,7 @@ describe('wrapStore', function () {
     const expectedSetupMessage = {
       type: STATE_TYPE,
       payload: serializer(firstState)
-    }
+    };
     const expectedPatchMessage = {
       type: PATCH_STATE_TYPE,
       payload: serializer(shallowDiff(firstState, secondState))

--- a/test/wrapStore.test.js
+++ b/test/wrapStore.test.js
@@ -1,9 +1,11 @@
 import '@babel/polyfill';
 
 import sinon from 'sinon';
+import should from 'should';
 
 import {wrapStore} from '../src';
-import {DISPATCH_TYPE} from '../src/constants';
+import shallowDiff from "../src/wrap-store/shallowDiff";
+import {DISPATCH_TYPE, STATE_TYPE, PATCH_STATE_TYPE} from '../src/constants';
 
 describe('wrapStore', function () {
   const portName = 'test';
@@ -56,59 +58,150 @@ describe('wrapStore', function () {
     return listeners;
   }
 
-  it('should dispatch actions received on onMessage to store', function () {
+  describe("on receiving messages", function() {
+    let listeners, store, payload, message, sender, callback;
+
+    beforeEach(function() {
+      listeners = setupListeners();
+      store = {
+        dispatch: sinon.spy(),
+      };
+
+      payload = {
+        a: 'a',
+      };
+      message = {
+        type: DISPATCH_TYPE,
+        portName,
+        payload
+      };
+      sender = {};
+      callback = () => {}; // noop.  Maybe should validate it is invoked?
+    });
+
+    it('should dispatch actions received on onMessage to store', function () {
+      wrapStore(store, {portName});
+      listeners.onMessage.forEach(l => l(message, sender, callback));
+
+      store.dispatch.calledOnce.should.eql(true);
+      store.dispatch
+        .alwaysCalledWith(
+          Object.assign({}, payload, {
+            _sender: sender,
+          }),
+        )
+        .should.eql(true);
+    });
+  
+    it('should not dispatch actions received on onMessage for other ports', function () {
+      wrapStore(store, {portName});
+      message.portName = portName + '2';
+      listeners.onMessage.forEach(l => l(message, sender, callback));
+
+      store.dispatch.notCalled.should.eql(true);
+    });
+  
+    it('should deserialize incoming messages correctly', function () {
+      const deserializer = sinon.spy(JSON.parse);
+      wrapStore(store, {portName, deserializer});
+      message.payload = JSON.stringify(payload);
+      listeners.onMessage.forEach(l => l(message, sender, callback));
+
+      deserializer.calledOnce.should.eql(true);
+      store.dispatch
+        .alwaysCalledWith(
+          Object.assign({}, payload, {
+            _sender: sender,
+          }),
+        )
+        .should.eql(true);
+    });
+
+    it('should not deserialize incoming messages for other ports', function () {
+      const deserializer = sinon.spy(JSON.parse);
+      wrapStore(store, {portName, deserializer});
+      message.portName = portName + '2';
+      message.payload = JSON.stringify(payload);
+      listeners.onMessage.forEach(l => l(message, sender, callback));
+
+      deserializer.called.should.eql(false);
+    });
+  });
+
+  it('should serialize initial state and subsequent patches correctly', function () {
     const listeners = setupListeners();
+    
+    // Mock store subscription
+    const subscribers = [];
+    const store = {
+      subscribe: subscriber => {
+        subscribers.push(subscriber);
+        return () => ({})
+      },
+      getState: () => ({})
+    };
+    
+    // Stub state access (the first access will be on
+    // initialization, and the second will be on update)
+    const firstState = { a: 1, b: 2 };
+    const secondState = { a: 1, b: 3, c: 5 };
+    sinon.stub(store, 'getState')
+        .onFirstCall().returns(firstState)
+        .onSecondCall().returns(secondState)
+
+    // Mock the port object for onConnect and spy on postMessage
+    const port = {
+      name: portName,
+      postMessage: sinon.spy(),
+      onDisconnect: {
+        addListener: () => ({})
+      }
+    };
+
+    const serializer = (payload) => JSON.stringify(payload);
+
+    wrapStore(store, {portName, serializer});
+
+    // Simulate a port connection with the mocked port
+    listeners.onConnect.forEach(l => l(port));
+    // Simulate a state update by calling subscribers
+    subscribers.forEach(subscriber => subscriber());
+
+    const expectedSetupMessage = {
+      type: STATE_TYPE,
+      payload: serializer(firstState)
+    }
+    const expectedPatchMessage = {
+      type: PATCH_STATE_TYPE,
+      payload: serializer(shallowDiff(firstState, secondState))
+    };
+
+    port.postMessage.calledTwice.should.eql(true);
+    port.postMessage.firstCall.args[0].should.eql(expectedSetupMessage);
+    port.postMessage.secondCall.args[0].should.eql(expectedPatchMessage);
+  });
+
+  describe("when validating options", function () {
     const store = {
       dispatch: sinon.spy(),
     };
 
-    wrapStore(store, {portName});
+    it('should throw an error if portName is not present', function () {
+      should.throws(() => {
+        wrapStore(store, {});
+      }, Error);
+    });
 
-    const payload = {
-      a: 'a',
-    };
-    const message = {
-      type: DISPATCH_TYPE,
-      portName,
-      payload,
-    };
-    const sender = {};
-    const callback = () => {}; // noop.  Maybe should validate it is invoked?
+    it('should throw an error if serializer is not a function', function () {
+      should.throws(() => {
+        wrapStore(store, { portName, serializer: "abc" });
+      }, Error);
+    });
 
-    listeners.onMessage.forEach(l => l(message, sender, callback));
-    store.dispatch.calledOnce.should.eql(true);
-    store.dispatch
-      .alwaysCalledWith(
-        Object.assign({}, payload, {
-          _sender: sender,
-        }),
-      )
-      .should.eql(true);
+    it('should throw an error if deserializer is not a function', function () {
+      should.throws(() => {
+        wrapStore(store, {portName, deserializer: "abc"});
+      }, Error);
+    });
   });
-
-  it(
-    'should not dispatch actions received on onMessage for other ports',
-    function () {
-      const listeners = setupListeners();
-      const store = {
-        dispatch: sinon.spy(),
-      };
-
-      wrapStore(store, {portName});
-
-      const payload = {
-        a: 'a',
-      };
-      const message = {
-        type: DISPATCH_TYPE,
-        portName: portName + '2',
-        payload,
-      };
-      const sender = {};
-      const callback = () => {}; // noop.  Maybe should validate it is invoked?
-
-      listeners.onMessage.forEach(l => l(message, sender, callback));
-      store.dispatch.notCalled.should.eql(true);
-    },
-  );
 });

--- a/test/wrapStore.test.js
+++ b/test/wrapStore.test.js
@@ -1,4 +1,4 @@
-import 'babel-polyfill';
+import '@babel/polyfill';
 
 import sinon from 'sinon';
 


### PR DESCRIPTION
- Add new `serializer` and `deserializer` options for `wrapStore` and `Store`, which will serialize all outgoing messages and deserialize all incoming messages.
- Update README

Note: When testing in an actual extension, I found it necessary to wrap all of the messaging functions (e.g. `port.postMessage` or `chrome.runtime.onMessage.addListener`) in anonymous functions, rather than passing the function references directly. If I didn't, Chrome gave me the following error:
```
Uncaught TypeError: Method called without a valid receiver (this). Did you forget to call .bind()?
  at getPrivateImpl (extensions::utils:119:16)
  at publicClassPrototype.(anonymous function) (extensions::utils:137:20)
...
```
I'm not sure what's causing this, but would welcome ideas. It feels unnecessary to have to wrap all of the calls.
