### PR TITLE
Support for promises in alias actions

### DIFF
--- a/src/alias/alias.js
+++ b/src/alias/alias.js
@@ -6,9 +6,14 @@
 export default aliases => () => next => action => {
   const alias = aliases[action.type];
 
-  if (alias) {
-    return next(alias(action));
+  if (!alias) {
+    return next(action);
+  }
+  const aliasResponse = alias(action);
+  if (typeof aliasResponse.then === "function") {
+    aliasResponse.then(result => next(result));
+  } else {
+    return next(aliasResponse);
   }
 
-  return next(action);
 };


### PR DESCRIPTION
I've found checking for and fulfilling promises in alias actions very useful. It makes it much simpler to dispatch requests for information only available to the background process. Any reason not to do this?