### PR TITLE
do not package .babelrc

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,4 @@
 src/
 .idea/
 test/
+.babelrc


### PR DESCRIPTION
Having this file in the dependency tree of my application breaks the build because it introduces config invalid for it (I am using Rollup with Babel). I don't think this file is necessary in the NPM package because the code is published already transpiled, so I think it's best to `.npmignore` it.