### PR TITLE
Don't treat falsy values as removed properties

### DIFF
--- a/src/wrap-store/shallowDiff.js
+++ b/src/wrap-store/shallowDiff.js
@@ -26,7 +26,7 @@ export default function shallowDiff(oldObj, newObj) {
   });
 
   Object.keys(oldObj).forEach(key => {
-    if (!newObj[key]) {
+    if (!newObj.hasOwnProperty(key)) {
       difference.push({
         key,
         change: DIFF_STATUS_REMOVED,

--- a/test/shallowDiff.js
+++ b/test/shallowDiff.js
@@ -38,4 +38,49 @@ describe('#shallowDiff()', () => {
       }
     ]);
   });
+
+  it('should not mark flasy values as removed', () => {
+    const old = { a: 1, b: 2, c: 3, d: 4, e: 5, f: 6, g: 7 };
+    const latest = {a: 0, b: null, c: undefined, d: false, e: NaN, f: '', g: ""};
+    const diff = shallowDiff(old, latest);
+
+    diff.length.should.eql(7);
+    diff.should.eql([
+      {
+        key: 'a',
+        value: 0,
+        change: DIFF_STATUS_UPDATED,
+      },
+      {
+        key: 'b',
+        value: null,
+        change: DIFF_STATUS_UPDATED,
+      },
+      {
+        key: 'c',
+        value: undefined,
+        change: DIFF_STATUS_UPDATED,
+      },
+      {
+        key: 'd',
+        value: false,
+        change: DIFF_STATUS_UPDATED,
+      },
+      {
+        key: 'e',
+        value: NaN,
+        change: DIFF_STATUS_UPDATED,
+      },
+      {
+        key: 'f',
+        value: '',
+        change: DIFF_STATUS_UPDATED,
+      },
+      {
+        key: 'g',
+        value: "",
+        change: DIFF_STATUS_UPDATED,
+      }
+    ]);
+  });
 });


### PR DESCRIPTION
Should fix #147, basically all the falsy values got tagged as changed but also as removed in the second check, resuling in values like `null` `0` `false` etc. to be removed while they should be valid values.

I could understand if you would like some changes or whatnot since this change could be breaking for people who rely on this behavior.

Cheers!