### PR TITLE
run function onDisconnectHook

### DIFF
--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -41,7 +41,7 @@ export default (store, {
   dispatchResponder,
   serializer = noop,
   deserializer = noop,
-  onPortClosed
+  onDisconnectHook = noop
 }) => {
   if (!portName) {
     throw new Error('portName is required in options');
@@ -51,6 +51,9 @@ export default (store, {
   }
   if (typeof deserializer !== 'function') {
     throw new Error('deserializer must be a function');
+  }
+  if (typeof onDisconnectHook !== 'function') {
+    throw new Error('onDisconnectHook must be a function');
   }
 
   // set dispatch responder as promise responder
@@ -112,8 +115,8 @@ export default (store, {
 
     // when the port disconnects, unsubscribe the sendState listener
     port.onDisconnect.addListener(unsubscribe);
-    if (onPortClosed) {
-      port.onDisconnect.addListener(onPortClosed);
+    if (onDisconnectHook) {
+      port.onDisconnect.addListener(onDisconnectHook);
     }
 
     // Send store's initial state through port

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -112,7 +112,9 @@ export default (store, {
 
     // when the port disconnects, unsubscribe the sendState listener
     port.onDisconnect.addListener(unsubscribe);
-    if (onPortClosed) port.onDisconnect.addListener(onPortClosed);
+    if (onPortClosed) {
+      port.onDisconnect.addListener(onPortClosed);
+    }
 
     // Send store's initial state through port
     serializedMessagePoster({

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -40,7 +40,8 @@ export default (store, {
   portName,
   dispatchResponder,
   serializer = noop,
-  deserializer = noop
+  deserializer = noop,
+  onPortClosed
 }) => {
   if (!portName) {
     throw new Error('portName is required in options');
@@ -111,6 +112,7 @@ export default (store, {
 
     // when the port disconnects, unsubscribe the sendState listener
     port.onDisconnect.addListener(unsubscribe);
+    if (onPortClosed) port.onDisconnect.addListener(onPortClosed);
 
     // Send store's initial state through port
     serializedMessagePoster({


### PR DESCRIPTION
By nature of Chrome extension architecture, it is difficult to clear/reset state when a popover closes. This is addressed in https://github.com/tshaddix/react-chrome-redux/issues/128. However, a potential workaround suggested - listening to `beforeunload` event on the popover window, and dispatching a reset action there - does not seem to work as expected.

In any case, this PR enables the following pattern:

```
const store = createStore(/* usual humbug */)

const onPortClosed = () => store.dispatch({ type: 'RESET_STATE' })

wrapStore(store, { portName: 'ENGAGE_FOR_CHROME', onPortClosed })
```