### PR TITLE
[Proposal] Use prepublishOnly instead of prepare & prepublish combo

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,10 @@
     "lint-src": "./node_modules/.bin/eslint src/**/*.js",
     "lint-test": "./node_modules/.bin/eslint test/**/*.js",
     "lint": "npm run lint-src && npm run lint-test",
-    "prepublish": "./node_modules/.bin/babel src --out-dir lib",
+    "prepublishOnly": "babel src --out-dir lib",
     "pretest": "./node_modules/.bin/babel src --out-dir lib",
     "test-run": "./node_modules/.bin/mocha --require babel-core/register",
-    "test": "npm run lint && npm run test-run",
-    "prepare": "npm run prepublish"
+    "test": "npm run lint && npm run test-run"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Two main reasons:
- `prepare` simply calls `prepublish` and nothing more, while `prepublishOnly` the same as `prepare` are called before packing the package, so instead of two commands there's one
- `prepublish` is always triggered on every `npm install` therefore prolonging the process, while `prepublishOnly` is triggered only when there is an intention of publishing the package