### PR TITLE
code for handling mozilla and firefox browser communication

### DIFF
--- a/src/store/Store.js
+++ b/src/store/Store.js
@@ -31,15 +31,19 @@ class Store {
     if (typeof patchStrategy !== 'function') {
       throw new Error('patchStrategy must be one of the included patching strategies or a custom patching function');
     }
+    
+    const isChrome = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
+
+    const allGlobal= isChrome === true ? chrome : browser;
 
     this.portName = portName;
     this.readyResolved = false;
     this.readyPromise = new Promise(resolve => this.readyResolve = resolve);
 
-    this.extensionId = extensionId; // keep the extensionId as an instance variable
-    this.port = chrome.runtime.connect(this.extensionId, {name: portName});
+    this.extensionId = allGlobal.runtime.id; // keep the extensionId as an instance variable
+    this.port = allGlobal.runtime.connect(this.extensionId, {name: portName});
     this.serializedPortListener = withDeserializer(deserializer)((...args) => this.port.onMessage.addListener(...args));
-    this.serializedMessageSender = withSerializer(serializer)((...args) => chrome.runtime.sendMessage(...args), 1);
+    this.serializedMessageSender = withSerializer(serializer)((...args) => allGlobal.runtime.sendMessage(...args), 1);
     this.listeners = [];
     this.state = state;
     this.patchStrategy = patchStrategy;

--- a/src/wrap-store/wrapStore.js
+++ b/src/wrap-store/wrapStore.js
@@ -94,6 +94,10 @@ export default (store, {
 
     const serializedMessagePoster = withSerializer(serializer)((...args) => port.postMessage(...args));
 
+    const isChrome = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);
+    
+    const allGlobal= isChrome === true ? chrome : browser;
+
     let prevState = store.getState();
 
     const patchState = () => {
@@ -129,13 +133,13 @@ export default (store, {
   /**
    * Setup action handler
    */
-  withPayloadDeserializer((...args) => chrome.runtime.onMessage.addListener(...args))(dispatchResponse, shouldDeserialize);
+  withPayloadDeserializer((...args) => allGlobal.runtime.onMessage.addListener(...args))(dispatchResponse, shouldDeserialize);
 
   /**
    * Setup external action handler
    */
-  if (chrome.runtime.onMessageExternal) {
-    withPayloadDeserializer((...args) => chrome.runtime.onMessageExternal.addListener(...args))(dispatchResponse, shouldDeserialize);
+  if (allGlobal.runtime.onMessageExternal) {
+    withPayloadDeserializer((...args) => allGlobal.runtime.onMessageExternal.addListener(...args))(dispatchResponse, shouldDeserialize);
   } else {
     console.warn('runtime.onMessageExternal is not supported');
   }
@@ -143,13 +147,13 @@ export default (store, {
   /**
    * Setup extended connection
    */
-  chrome.runtime.onConnect.addListener(connectState);
+  allGlobal.runtime.onConnect.addListener(connectState);
 
   /**
    * Setup extended external connection
    */
-  if (chrome.runtime.onConnectExternal) {
-    chrome.runtime.onConnectExternal.addListener(connectState);
+  if (allGlobal.runtime.onConnectExternal) {
+    allGlobal.runtime.onConnectExternal.addListener(connectState);
   } else {
     console.warn('runtime.onConnectExternal is not supported');
   }


### PR DESCRIPTION
Hi Team,

I would like propose a solution for my recent issue .

**Problem Statement:**-
The react-chrome-redux is working beautifully in chrome,I know it was intended for chrome as it's name indicates.Later I need use the same package for different browser like Firefox and Edge then the headache start for me.In order get the browser and pop up communication across different browser I did not any other package,so I slowly started implementing changes in the current react-chrome-redux package that will support other browser like Firefox and Edge so far.

 **Proposed solution:-**
I want to achieve the above problem statement with minimal change so I came up with the below approach.

const isChrome = /Chrome/.test(navigator.userAgent) && /Google Inc/.test(navigator.vendor);

Step 1:-check if browser is chrome or not

const allGlobal= isChrome === true ? chrome : browser;

Step2:- if browser is chrome use chrome api otherwise use browser api

Note:- Browser api is working for both mozilla and firefox

So I replaced all chrome api method with allGlobal .

Eg:-this.port = allGlobal.runtime.connect(this.extensionId, {name: portName});

With that minimal change I can able to support the browser and popup communication across the three different browsers

- Chrome
- Firefox
- Edge

I am hoping this will be helpful for people who are looking cross browser popup communication ,please let me know your feed back on the same.

Thanks & Regards,
Bala.