### PR TITLE
When oldObj is null and newObj is an object, diffValues attempts to compare keys anyways

### DIFF
--- a/src/strategies/deepDiff/diff.js
+++ b/src/strategies/deepDiff/diff.js
@@ -11,6 +11,10 @@ function shouldTreatAsValue(oldObj, newObj) {
 }
 
 function diffValues(oldObj, newObj, shouldContinue, context) {
+  // If it's null, use the current value
+  if (oldObj === null) {
+    return { change: DIFF_STATUS_UPDATED, value: newObj };
+  }
   // If it's a non-object, or if the type is changing, or if it's an array,
   // just go with the current value.
   if (shouldTreatAsValue(oldObj, newObj) || !shouldContinue(oldObj, newObj, context)) {

--- a/test/deepDiff.test.js
+++ b/test/deepDiff.test.js
@@ -184,6 +184,24 @@ describe('deepDiff strategy', () => {
       });
     });
 
+    describe('when a null value is being replaced with an object', () => {
+      it('should generate a diff', () => {
+        const old = { a: null };
+        const latest = { a: { b: 1 } };
+
+        const diff = deepDiff(old, latest);
+
+        diff.length.should.eql(1);
+        diff.should.eql([
+          {
+            key: 'a',
+            value: { b: 1 },
+            change: DIFF_STATUS_UPDATED,
+          }
+        ]);
+      });
+    });
+
     describe("shouldContinue param", () => {
 
       let old, latest, shouldContinue, diff;


### PR DESCRIPTION
Hi, I found a bug in the new `deepDiff` implementation that arises when a value in the state tree that was previously `null` is getting replaced with an object. The current implementation attempts to compare the keys in the new object against keys in the old object. This pull request reproduces the case in a test and explicitly handles `null` in the `diffValues` function.